### PR TITLE
[CI][#14] - Update ci coverage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,8 @@
   },
   "rules": {
     "no-return-await": "off",
-    "@typescript-eslint/return-await": "warn"
+    "@typescript-eslint/return-await": "warn",
+    "@typescript-eslint/consistent-type-exports": "off",
+    "@typescript-eslint/consistent-type-imports": "off"
   }
 }

--- a/ci-coverage/config.ts
+++ b/ci-coverage/config.ts
@@ -1,6 +1,10 @@
-export const metrics = {
+import { Metrics } from './coverage'
+
+const metrics: Metrics = {
   statement: 85,
   branch: 85,
   function: 90,
   line: 80
 }
+
+export { metrics }

--- a/ci-coverage/coverage.ts
+++ b/ci-coverage/coverage.ts
@@ -10,7 +10,7 @@ interface Metrics {
 
 type Report = [isValidStatement: boolean, isValidBranch: boolean, isValidFunction: boolean, isValidLine: boolean]
 
-export class Coverage {
+class Coverage {
   coverageString: string
 
   constructor (private readonly metrics: Metrics) {
@@ -58,3 +58,5 @@ export class Coverage {
     return report.every((element: boolean) => element)
   }
 }
+
+export { Coverage, Metrics }


### PR DESCRIPTION
Fixed #14 

I had to disable two lint rules (import and export) because it requires interfaces to be imported and exported using the **type** word, but this is unproductive when there are different objects coming from the same index. It's easier to use a single line of import.

_The rest is the same as the task requirements._